### PR TITLE
fix: unshift leftover data back onto the stream, NOT push

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ Multifeed.prototype.replicate = function (opts) {
           addMissingKeys(header.keys, function () {
             // push remainder of buffer
             var leftover = headerAccum.slice(expectedLen + 4)
-            self.push(leftover)
+            self.unshift(leftover)
             debug('[REPLICATION] starting hypercore replication')
             process.nextTick(startSync)
             next()


### PR DESCRIPTION
This covers the case where

1. I read a chunk from the through stream, parse the header, and have some leftover data from after the header
2. the through stream has some MORE buffered data already in it (maybe hypercore-protocol data)
3. the old code would `push` the leftover data, which would actually put the beginning of the post-header data AFTER whatever else was already in the stream
4. this would confuse/break hypercore-protocol, and no replication would happen